### PR TITLE
Update destination_branch from master to main (pre-rename)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
           source_file: 'FORRT_cv.pdf'
           destination_repo: 'forrtproject/forrtproject.github.io'
           destination_folder: 'static/files/'
-          destination_branch: 'master'
+          destination_branch: 'main'
           destination_branch_create: 'update-cv'
           user_email: 'riva.quiroga@uc.cl'
           user_name: 'rivaquiroga'


### PR DESCRIPTION
## Summary

The publish workflow opens a PR against \`forrtproject/forrtproject.github.io\` to ship the latest \`FORRT_cv.pdf\`. That repo's default branch is being renamed \`master\` → \`main\`, so this hardcoded \`destination_branch\` has to follow.

Should be merged before the rename on the site repo lands. The companion site PR is forrtproject/forrtproject.github.io#765.

🤖 Generated with [Claude Code](https://claude.com/claude-code)